### PR TITLE
Fixed build problem on windows

### DIFF
--- a/System/FilePath/Manip.hs
+++ b/System/FilePath/Manip.hs
@@ -21,8 +21,8 @@ import Control.Monad (liftM)
 import Data.Bits ((.&.))
 import System.Directory (removeFile)
 import System.IO (Handle, IOMode(..), hClose, openFile)
-import System.Posix.Files (fileMode, getFileStatus, rename, setFileMode)
-import System.Posix.Temp (mkstemp)
+import System.PosixCompat.Files (fileMode, getFileStatus, rename, setFileMode)
+import System.PosixCompat.Temp (mkstemp)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified System.IO as I

--- a/filemanip.cabal
+++ b/filemanip.cabal
@@ -18,8 +18,6 @@ Extra-Source-Files: README.markdown
 
 Library
   build-depends: base < 5, bytestring, directory, filepath, mtl, unix-compat
-  if !os(windows)
-    build-depends: unix
   if impl(ghc >= 6.10)
     build-depends:
       base >= 4


### PR DESCRIPTION
I switched the module imports over to using System.PosixCompat instead of System.Posix.

It now builds fine on Windows
