### PR TITLE
Don't fail in patterns of the `…*/…` form

### DIFF
--- a/System/FilePath/GlobPattern.hs
+++ b/System/FilePath/GlobPattern.hs
@@ -157,7 +157,6 @@ matchTerms [MatchDir] cs | pathSeparator `elem` cs = fail "path separator"
                          | otherwise = return ()
 matchTerms (MatchDir:ts) cs = matchDir cs >>= matchTerms ts
     where matchDir [] = fail "no match"
-          matchDir (c:_) | c == pathSeparator = fail "path separator"
           matchDir cs' = case matchTerms ts cs' of
                          Nothing -> matchDir $ tail cs'
                          _ -> return cs'


### PR DESCRIPTION
Internal matchDir would always fail if we were trying to match against a
separator after as it gave up before the separator even had the chance
to be consumed.

Closes #9
