### PR TITLE
Require unix-compat >= 0.3

### DIFF
--- a/filemanip.cabal
+++ b/filemanip.cabal
@@ -17,7 +17,7 @@ Build-type:         Simple
 Extra-Source-Files: README.markdown
 
 Library
-  build-depends: base < 5, bytestring, directory, filepath, mtl, unix-compat
+  build-depends: base < 5, bytestring, directory, filepath, mtl, unix-compat >= 0.3
   if impl(ghc >= 6.10)
     build-depends:
       base >= 4


### PR DESCRIPTION
`System.PosixCompat.Temp` is not available before `unix-compat-0.3`.

As a Hackage trustee I made relevant revisions.